### PR TITLE
Fix rom dirs symlinks

### DIFF
--- a/net._86box._86Box.ROMs.yaml
+++ b/net._86box._86Box.ROMs.yaml
@@ -31,5 +31,5 @@ modules:
       - install -Dm755 apply_extra ${FLATPAK_DEST}/bin/apply_extra
       - |
         for dir in floppy hdd icons machines network printer scsi sound video; do
-          ln -s extra/$dir $dir
+          ln -s extra/$dir ${FLATPAK_DEST}/$dir
         done


### PR DESCRIPTION
Install prefix was accidentally omitted, causing symlinks to be created in the build dir instead of install dir.