### PR TITLE
Update KDE runtime to 6.8

### DIFF
--- a/net._86box._86Box.ROMs.yaml
+++ b/net._86box._86Box.ROMs.yaml
@@ -2,7 +2,7 @@ id: net._86box._86Box.ROMs
 build-extension: true
 runtime: net._86box._86Box
 runtime-version: stable
-sdk: org.kde.Sdk//5.15-23.08
+sdk: org.kde.Sdk//6.8
 tags:
   - proprietary
 


### PR DESCRIPTION
It may not be needed because this is an Flatpak extension